### PR TITLE
Search improvements

### DIFF
--- a/gowild_scraper.py
+++ b/gowild_scraper.py
@@ -2,6 +2,8 @@ import random, time, requests, json, html
 from bs4 import BeautifulSoup
 from datetime import datetime, timedelta
 import browsercookie
+import argparse
+
 
 # TODO 
 # Speed up processing time
@@ -30,8 +32,11 @@ destinations = {
     'PVR': 'Puerto Vallarta, MX', 
     'MTY': 'Monetrrey, MX', 
     'CUN': 'Cancun, MX', 
-    'CZM': 'Cozumel, MX', 
+    'CZM': 'Cozumel, MX',  
     'SXM': 'St. Maarten', 
+    'BQN': 'Aguadilla, Puerto Rico', 
+    'PSE': 'Ponce, Puerto Rico', 
+    'SJU': 'San Juan, Puerto Rico',
     'PHX': 'Phoenix', 
     'XNA': 'Arkansas', 
     'LIT': 'Little Rock, AR', 
@@ -88,9 +93,6 @@ destinations = {
     'MDT': 'Pennsylvania', 
     'PHL': 'Philadelphia', 
     'PIT': 'Pittsburgh', 
-    'BQN': 'Aguadilla, Puerto Rico', 
-    'PSE': 'Ponce, Puerto Rico', 
-    'SJU': 'San Juan, Puerto Rico', 
     'CHS': 'Charleston, South Carolina', 
     'MYR': 'Myrtle Beach, SC', 
     'TYS': 'Tennessee', 
@@ -110,7 +112,7 @@ destinations = {
     'MSN': 'Madison', 
     'MKE': 'Milwaukee'}
 
-def get_flight_html(origin, destinations, date, session):
+def get_flight_html(origin, destinations, date, session, cjs, start_index=0):
     user_agents = [
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
@@ -120,47 +122,50 @@ def get_flight_html(origin, destinations, date, session):
 
     f = open("destinations.txt", "a")
     f.write("Origin: " + origin + "\n")
-    for dest in destinations.keys():
+    destination_keys = list(destinations.keys()) # Retrieve a list of destination keys
+    for i in range(start_index, len(destination_keys)):
+        dest = destination_keys[i]
         # Choose a random User-Agent header
         header = {
             "User-Agent": random.choice(user_agents),
         }
-        cj = browsercookie.load()
+        cj = browsercookie.chrome() if cjs else None
 
-        time.sleep(random.uniform(0.5,1.5))
-        # Get schedule data for the route
-        schedule_url = f"https://booking.flyfrontier.com/Flight/RetrieveSchedule?calendarSelectableDays.Origin={origin}&calendarSelectableDays.Destination={dest}"
-        schedule_response = requests.Session().get(schedule_url, headers=header, cookies=cj)
-        
-        if schedule_response.status_code == 200:
-            schedule_data = schedule_response.json()
-            disabled_dates = schedule_data['calendarSelectableDays']['disabledDates']
-            last_available_date = schedule_data['calendarSelectableDays']['lastAvailableDate']
+        if cjs:
+            time.sleep(random.uniform(0.5,1.5))
+            # Get schedule data for the route
+            schedule_url = f"https://booking.flyfrontier.com/Flight/RetrieveSchedule?calendarSelectableDays.Origin={origin}&calendarSelectableDays.Destination={dest}"
+            schedule_response = requests.Session().get(schedule_url, headers=header, cookies=cj) if cjs else requests.Session().get(schedule_url, headers=header)
+            
+            if schedule_response.status_code == 200:
+                schedule_data = schedule_response.json()
+                disabled_dates = schedule_data['calendarSelectableDays']['disabledDates']
+                last_available_date = schedule_data['calendarSelectableDays']['lastAvailableDate']
 
-            # Convert the input date to the same format as the disabled dates list
-            formatted_date = datetime.strptime(date.replace('%20', ' '), '%b %d, %Y').strftime('%-m/%-d/%Y')
+                # Convert the input date to the same format as the disabled dates list
+                formatted_date = datetime.strptime(date.replace('%20', ' '), '%b %d, %Y').strftime('%-m/%-d/%Y')
 
-            # Check if the date is in the list of disabled dates
-            if formatted_date in disabled_dates or last_available_date == '0001-01-01 00:00:00':
-                print(f"No flights available on {formatted_date} from {origin} to {dest}. Date skipped.")
-                continue
-        else:
-            print(f"Problem accessing URL: code {schedule_response.status_code}\n url = " + schedule_url)
+                # Check if the date is in the list of disabled dates
+                if formatted_date in disabled_dates or last_available_date == '0001-01-01 00:00:00':
+                    print(f"{i}. No flights available on {formatted_date} from {origin} to {dest}. Date skipped.")
+                    continue
+            else:
+                print(f"{i}. Problem accessing URL: code {schedule_response.status_code}\n url = " + schedule_url)
 
         
         # Mimic human-like behavior by adding delays between requests
         delay = random.uniform(2, 5)  # Random delay between 2 to 5 seconds
         time.sleep(delay)
         url = f"https://booking.flyfrontier.com/Flight/InternalSelect?o1={origin}&d1={dest}&dd1={date}&ADT=1&mon=true&promo="
-        response = session.get(url, headers=header, cookies=cj)
+        response = session.get(url, headers=header, cookies=cj) if cjs else session.get(url, headers=header)
         if (response.status_code == 200):
             decoded_data = extract_html(response)
             if (decoded_data != 'NoneType'):
                 extract_json(decoded_data, origin, dest, date)
                 f.write(dest + ",")
         else:
-            print(f"Problem accessing URL: code {response.status_code}\n url = " + url)
-            continue
+            print(f"{i}. Problem accessing URL: code {response.status_code}\n url = " + url)
+            break
     f.close()
         
 def extract_json(flight_data, origin, dest, date):
@@ -211,16 +216,27 @@ def print_dests(origin):
 
 def main():
     global destinations
-    origin = input("Origin IATA airport code: ").upper()
-    input_dates = input("Show flights for:\n\tToday: 1\n\tTommorrow: 2\n\tBoth: 3\n\tTo Exit: 0\n")
+
+    parser = argparse.ArgumentParser(description='Check flight availability.')
+    parser.add_argument('-o', '--origin', type=str, required=True, help='Origin IATA airport code.')
+    parser.add_argument('-d', '--dates', type=str, required=True, help='Show flights for:\n\tToday: 1\n\tTommorrow: 2\n\tBoth: 3')
+    parser.add_argument('-c', '--cjs', action='store_true', help='Use browser cookies.')
+    parser.add_argument('-r', '--resume', type=int, default=0, help='Index of airport to resume from. Use index 21 to only search for contiguous US destinations.')
+
+    args = parser.parse_args()
+
+    origin = args.origin.upper()
+    input_dates = args.dates
+    cjs = args.cjs
     today = datetime.today()    
     session = requests.Session()
+    resume = args.resume
 
     if input_dates in ['1','3']:
         # Todays date in URL format
         travel_today = today.strftime("%b-%d,-%Y").replace("-", "%20")
         print("\nFlights for today:")
-        get_flight_html(origin, destinations, travel_today, session)
+        get_flight_html(origin, destinations, travel_today, session, cjs, resume)
         print_dests(origin)
 
     if input_dates in ['2','3']:
@@ -228,14 +244,8 @@ def main():
         tmrw = today + timedelta(days=1)
         travel_tmrw = tmrw.strftime("%b-%d,-%Y").replace("-", "%20")
         print("\nFlights for tommorrow:")
-        get_flight_html(origin, destinations, travel_tmrw, session)
+        get_flight_html(origin, destinations, travel_tmrw, session, cjs, resume)
         print_dests(origin)
-
-    if input_dates == '0':
-        return
-    else:
-        print("Retry")
-        main()
 
 if __name__ == "__main__":
     main()

--- a/gowild_scraper.py
+++ b/gowild_scraper.py
@@ -129,7 +129,7 @@ def get_flight_html(origin, destinations, date, session, cjs, start_index=0):
         if dest == origin:
             print('cannot search between identical origin and destination')
             continue
-        
+
         # Choose a random User-Agent header
         header = {
             "User-Agent": random.choice(user_agents),

--- a/gowild_scraper.py
+++ b/gowild_scraper.py
@@ -125,6 +125,11 @@ def get_flight_html(origin, destinations, date, session, cjs, start_index=0):
     destination_keys = list(destinations.keys()) # Retrieve a list of destination keys
     for i in range(start_index, len(destination_keys)):
         dest = destination_keys[i]
+
+        if dest == origin:
+            print('cannot search between identical origin and destination')
+            continue
+        
         # Choose a random User-Agent header
         header = {
             "User-Agent": random.choice(user_agents),

--- a/gowild_watcher.py
+++ b/gowild_watcher.py
@@ -1,0 +1,133 @@
+import random, time, requests, json, html
+from bs4 import BeautifulSoup
+from datetime import datetime, timedelta
+import argparse
+import smtplib
+from email.mime.text import MIMEText
+
+def send_email(subject, body):
+    msg = MIMEText(body)
+    msg['Subject'] = subject
+    msg['From'] = None
+    msg['To'] = None
+
+    # Credentials
+    username = None
+    password = None
+
+    if (username == None or password == None):
+        print("Please enter your email credentials in gowild_watcher.py")
+        return
+
+    # The actual mail send
+    server = smtplib.SMTP('smtppro.zoho.com:587')
+    server.starttls()
+    server.login(username, password)
+    server.send_message(msg)
+    server.quit()
+
+def get_flight_html(origin, destination, date, session, cjs):
+    user_agents = [
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+    ]
+
+    header = {"User-Agent": random.choice(user_agents),}
+    delay = random.uniform(2, 5)  # Random delay between 2 to 5 seconds
+    time.sleep(delay)
+    url = f"https://booking.flyfrontier.com/Flight/InternalSelect?o1={origin}&d1={destination}&dd1={date}&ADT=1&mon=true&promo="
+    response = session.get(url, headers=header)
+    if (response.status_code == 200):
+        decoded_data = extract_html(response)
+        if (decoded_data != 'NoneType'):
+            return extract_json(decoded_data, origin, destination, date)
+    else:
+        print(f"Problem accessing URL: code {response.status_code}\n url = " + url)
+    
+    return 0
+
+def extract_json(flight_data, origin, dest, date):
+    # Extract the flights with isGoWildFareEnabled as true
+    try:
+        flights = flight_data['journeys'][0]['flights']
+    except (TypeError, KeyError):
+        return
+    if (flights == None):
+        return
+    go_wild_count = 0
+
+    for flight in flights:
+        if flight["isGoWildFareEnabled"]:
+            if (go_wild_count == 0):
+                print(f"\n{origin} to {dest} available:")
+            go_wild_count+=1
+            info = flight['legs'][0]
+            print(f"flight {go_wild_count}. {flight['stopsText']}")
+            print(f"\tDate: {info['departureDate'][5:10]}")
+            print(f"\tDepart: {info['departureDateFormatted']}")
+            print(f"\tTotal flight time: {flight['duration']}")
+            print(f"Price: ${flight['goWildFare']}")
+            # if go wild seats value is provided
+            if flight['goWildFareSeatsRemaining'] is not None:
+                print(f"Go Wild: {flight['goWildFareSeatsRemaining']}\n")
+            body = f"flight {go_wild_count}.\n{flight['stopsText']}\nDate: {info['departureDate'][5:10]}\nDepart: {info['departureDateFormatted']}\nTotal flight time: {flight['duration']}\nPrice: ${flight['goWildFare']}"
+            send_email(f"{origin} to {dest}: {go_wild_count} Go Wild flights available for {date.replace('%20', ' ')}", body)
+            
+            
+    if (go_wild_count != 0):
+        print(f"{origin} to {dest}: {go_wild_count} Go Wild flights available for {date.replace('%20', ' ')}")
+    else:
+        print(f"No flights from {origin} to {dest}")
+    return go_wild_count
+
+def extract_html(response):
+    # Parse the HTML source using BeautifulSoup
+    soup = BeautifulSoup(response.text, "html.parser")
+    
+    # Find all <script> tags with type="text/javascript" and extract their contents
+    scripts = soup.find("script", type="text/javascript")
+    decoded_data = html.unescape(scripts.text)
+    decoded_data = decoded_data[decoded_data.index('{'):decoded_data.index(';')-1]
+    return json.loads(decoded_data)
+
+def main():
+    parser = argparse.ArgumentParser(description='Watch for flight availability.')
+    parser.add_argument('-o', '--origin', type=str, required=True, help='Origin IATA airport code.')
+    parser.add_argument('-d', '--destination', type=str, required=True, help='Destination IATA airport code.')
+    parser.add_argument('-t', '--dates', type=str, required=True, help='watch flights for:\n\tToday: 1\n\tTommorrow: 2\n\tBoth: 3')
+    
+    args = parser.parse_args()
+    
+    origin = args.origin.upper()
+    destination = args.destination.upper()
+    input_dates = args.dates
+
+    # Create a session to store cookies
+    session = requests.Session()
+    cjs = requests.cookies.RequestsCookieJar()
+    session.cookies = cjs
+
+    # Get the current date
+    today = datetime.today()
+    travel_today = today.strftime("%b-%d,-%Y").replace("-", "%20")
+    tmrw = today + timedelta(days=1)
+    travel_tmrw = tmrw.strftime("%b-%d,-%Y").replace("-", "%20")
+
+    total_count = 0
+
+    if input_dates in ['1','3']:
+        print('searching for today')
+        total_count += get_flight_html(origin, destination, travel_today, session, cjs)
+    if input_dates in ['2','3']:
+        print('searching for tommorrow')
+        total_count += get_flight_html(origin, destination, travel_tmrw, session, cjs)
+
+    if total_count == 0:
+        print('no flights found, retrying in 5 minutes')
+        time.sleep(300)
+        main()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- adds CLI arguments for taking cookies from browser (if you get 403 rate limited, this can be remedied by clicking on the 403 link in the command line and solving the captcha)
- adds schedule search, short circuits the slow internalSearch api call with the much faster schedule search one. unfortunately this one is also secured by perimeterX so you gotta delay between calls.
- allows resuming from the middle of a failed search (and reordered destinations to allow for contiguous US only search)
- adds watcher variant that watches a single route and sends an email/text when route becomes available

to run the program now, you would specify CLI arguments as follows:
`python gowild_scraper.py -o DEN -d 2 -r 21 -c`

-o DEN = DEN as origin
-d 2 = search mode 2, tomorrow
-r 21 = start search from index 21 (only contiguous US)
-c = steal my browser cookies (be careful, always inspect the code before running this if you've pulled new code)
-h, --help = display docs for these CLI arguments